### PR TITLE
Handle explicit formula errors

### DIFF
--- a/lib/src/xlsx.dart
+++ b/lib/src/xlsx.dart
@@ -348,6 +348,8 @@ class XlsxDecoder extends SpreadsheetDecoder {
       case 'b':
         value = _parseValue(node.findElements('v').first) == '1';
         break;
+      // error
+      case 'e': 
       // formula
       case 'str':
         // <c r="C6" s="1" vm="15" t="str">


### PR DESCRIPTION
This cell from an Excel spreadsheet contains a formula error. Apparently, for xlsx format, cells containing formula errors are automatically set to `str` type by Google Sheets, **but** Excel (perhaps certain versions) gives them `t="e"`. In the xlsx value parser, these currently fall through the default case, as a number, and thus result in an unhandled `FormatException`. This PR explicitly has them fall through the str case.
 
```
<c r="O14" s="3" t="e">
  <f t="shared" si="3"/>
  <v>#DIV/0!</v>
</c>
```

The default case for the ods parser is already as a string, and besides, I believe the type attribute the parser checks for ods cells _will_ be `string` in formula error cases anyway.

I would've included a unit test, but I don't actually have a copy of Excel myself so I can't simply produce a file for testing. If it's necessarily, let me know, and I'll see what I can do. 

Thanks!